### PR TITLE
Disable multiple expectations check

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mfind-rubocop-rspec (1.2.0)
+    mfind-rubocop-rspec (1.2.1)
       rubocop (~> 0.80.0)
       rubocop-performance (~> 1.5.2)
       rubocop-rspec (~> 1.38.1)
@@ -12,11 +12,11 @@ GEM
     ast (2.4.0)
     jaro_winkler (1.5.4)
     parallel (1.19.1)
-    parser (2.7.0.3)
+    parser (2.7.1.2)
       ast (~> 2.4.0)
     rainbow (3.0.0)
     rexml (3.2.4)
-    rubocop (0.80.0)
+    rubocop (0.80.1)
       jaro_winkler (~> 1.5.1)
       parallel (~> 1.10)
       parser (>= 2.7.0.1)
@@ -38,4 +38,4 @@ DEPENDENCIES
   mfind-rubocop-rspec!
 
 BUNDLED WITH
-   2.0.2
+   2.1.4

--- a/default.yml
+++ b/default.yml
@@ -1,4 +1,4 @@
-require: 
+require:
   - rubocop-performance
   - rubocop-rspec
 
@@ -23,7 +23,7 @@ Metrics/BlockLength:
   Max: 25
   Exclude:
     - "**/*_spec.rb"
-  
+
 Metrics/BlockNesting:
   Max: 3
   Exclude:
@@ -65,4 +65,7 @@ RSpec/ContextWording:
   Enabled: false
 
 RSpec/NestedGroups:
+  Enabled: false
+
+RSpec/MultipleExpectations:
   Enabled: false

--- a/lib/mfind_rubocop_rspec.rb
+++ b/lib/mfind_rubocop_rspec.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module MfindRuboCopRSpec
-  VERSION = '1.2.0'
+  VERSION = '1.2.1'
 end


### PR DESCRIPTION
Każdy `it` uruchamia cały setup. Dlatego należy expectations grupować ze względu na znacznie wyższą wydajność 

```
describe UserCreator do
  it 'builds a user' do
    expect(user.name).to eq("John")
    expect(user.age).to eq(22)
  end
end
```